### PR TITLE
Entity DAO meta cache collision

### DIFF
--- a/library/entity/dao.php
+++ b/library/entity/dao.php
@@ -186,7 +186,7 @@
          * @return string
          */
         final protected static function _build_key_list_field($field_name) {
-            return static::ENTITY_NAME . ':' . self::META . "[{$field_name}]";
+            return static::ENTITY_NAME . ':' . self::META . ":{$field_name}";
         }
 
         /**


### PR DESCRIPTION
Entity DAO meta cache collision.
Two of the meta cache keys were colliding with each other.
